### PR TITLE
add `refreshElements` function to handle added or removed elements

### DIFF
--- a/src/jquery.ioslist.src.js
+++ b/src/jquery.ioslist.src.js
@@ -36,6 +36,19 @@
             this.$fakeHeader = this.$elem.find(this.options.selectors.stationaryHeader).eq(0);
             this.$fakeHeader.addClass(this.options.classes.stationaryHeader);
 
+            this.refreshElements();
+
+            this.$fakeHeader.text(this.elems[0].headerText);
+
+            this.$listWrapper.scroll(function() {
+                scope.testPosition();
+            });
+
+        },
+
+        refreshElements: function() {
+            var scope = this;
+            this.elems = [];
             this.$elem.find(this.options.selectors.groupContainer).each(function(index, elem) {
                 var $tmp_list = scope.$elem.find(scope.options.selectors.groupContainer).eq(index),
                     $tmp_header = $tmp_list.find(scope.options.selectors.groupHeader).eq(0),
@@ -51,13 +64,6 @@
                     'listBottom': $tmp_listHeight + $tmp_listOffset
                 });
             });
-
-            this.$fakeHeader.text(this.elems[0].headerText);
-
-            this.$listWrapper.scroll(function() {
-                scope.testPosition();
-            });
-
         },
 
         testPosition: function() {


### PR DESCRIPTION
This addresses https://github.com/brianhadaway/iOSList/issues/4.

My problem was that I wanted to use iOSList with an infinite scroll plugin, but when I scrolled to newly added section headers, they didn't push the old headers away. Re-calling `$wrapperElement.ioslist()` didn't work because the initialization process isn't idempotent, but the only thing that matters is the `elems` variable, so it seemed simplest to add a function to refresh it.

It might be good to update the README to show usage instructions too. e.g. something like:
```javascript
$('.my-list').ioslist().on('ajax:success', function() {
  // after adding new elements to the DOM
  $(this).data('instance').refreshElements();
});
```