### PR TITLE
Fixed main in package.json to work with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "title": "iOSList",
     "description": "iOS-style Sticky Headers with jQuery.",
     "version": "2.0.0",
-    "main": "src/jquery.ubaplayer.js",
+    "main": "dist/js/jquery.ioslist.min.js",
     "homepage": "https://brianhadaway.github.io/iOSList",
     "author": {
         "name": "Brian Hadaway",


### PR DESCRIPTION
Now you can require('jquery.ioslist')