### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ In your web page:
 ```
 
 ## Documentation
-###refreshElements
+### refreshElements
 ```
 $('.my-list').ioslist().on('ajax:success', function() {
   // after adding new elements to the DOM
@@ -72,7 +72,7 @@ $('.my-list').ioslist().on('ajax:success', function() {
 });
 ```
 
-###Configuration Options & Their Defaults
+### Configuration Options & Their Defaults
 
 @TODO
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
